### PR TITLE
Improve HF integration

### DIFF
--- a/net/CIDNet.py
+++ b/net/CIDNet.py
@@ -6,7 +6,9 @@ from net.HVI_transform import RGB_HVI
 from net.transformer_utils import *
 from net.LCA import *
 
-class CIDNet(nn.Module):
+from huggingface_hub import PyTorchModelHubMixin
+
+class CIDNet(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/Fediory/HVI-CIDNet", pipeline_tag="image-to-image", license="mit"):
     def __init__(self, 
                  channels=[36, 36, 72, 144],
                  heads=[1, 2, 4, 8],

--- a/net/CIDNet.py
+++ b/net/CIDNet.py
@@ -69,7 +69,7 @@ class CIDNet(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/Fedio
         self.I_LCA5 = I_LCA(ch3, head3)
         self.I_LCA6 = I_LCA(ch2, head2)
         
-        self.trans = RGB_HVI().cuda()
+        self.trans = RGB_HVI()
         
     def forward(self, x):
         dtypes = x.dtype


### PR DESCRIPTION
This PR improves the 🤗 integration by ensuring the weights can be automatically loaded using `from_pretrained` (and pushed to the hub `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. 

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

A single checkpoint can be pushed as follows:

```python
from net.CIDNet import CIDNet

model = CIDNet(...)

# equip with weights
model.load_state_dict(...)

# push to the hub
model = CIDNet.push_to_hub("your-hf-username/cidnet-lolv1")
```

After that, people can use it as follows:

```python
from net.CIDNet import CIDNet

model = CIDNet.from_pretrained("your-hf-username/cidnet-lolv1")
```

Moreover, `safetensors` is leveraged for weights serialization along with a `config.json`.

Kind regards,

Niels